### PR TITLE
Expand post links to the full height

### DIFF
--- a/source/stylesheets/views/_posts.css.scss
+++ b/source/stylesheets/views/_posts.css.scss
@@ -21,14 +21,19 @@ ul.posts {
 
   .info {
     @include float-left;
-    margin: 12px 0 0 80px;
+    margin-left: 80px;
   }
 
   h2 {
     font-size: 1.5rem;
 
-    a:visited {
-      color: lighten($text, 40%);
+    a {
+      display: inline-block;
+      line-height: $post-height;
+
+      &:visited {
+        color: lighten($text, 40%);
+      }
     }
   }
 


### PR DESCRIPTION
This is a small UX improvement. Basically it makes the full height of the post element `li` clickable by expanding an anchor.

It also doesn't need any top margin on the containing `div.info`, since `line-height` will center the text vertically.
