### PR TITLE
Support for ruby 2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
-    eventmachine (1.0.3)
+    eventmachine (1.0.7)
     excon (0.41.0)
     execjs (2.2.2)
     ffi (1.9.6)


### PR DESCRIPTION
Updated eventmachine to the latest version (1.0.7) that supports ruby 2.2. Previous version (1.0.3) crashes while installing the gem.