### PR TITLE
Preserving HTML entities in post titles

### DIFF
--- a/source/javascripts/templates/_posts.jst.skim
+++ b/source/javascripts/templates/_posts.jst.skim
@@ -2,7 +2,7 @@
   li class="#{Coven.Helpers.dashify(post.get('source'))}"
     .info
       h2
-        a href="#{post.get('url')}" => post.get('title')
+        a href="#{post.get('url')}" => @safe post.get('title')
         date
           ' #{Coven.Helpers.timeAgo post.get('external_created_at')}
           ' ago


### PR DESCRIPTION
Some of the titles have HTML entities in them which are being escaped. This should fix it.

Example:

![](https://photos-3.dropbox.com/t/2/AAAwZjiuPdosXBw1T7hqALC1cTzm8vdg1UGT1AhTwMnlOg/12/7209271/png/1024x768/3/1428282000/0/2/Screenshot%202015-04-06%2000.17.25.png/CLeCuAMgASACIAMoASgC/-cDuwr6wW7LgObji9MUMIDHVWs78ieesSBGZZMVS5Bw)