### PR TITLE
Fix mobile layout

### DIFF
--- a/source/stylesheets/mixins/_variables.scss
+++ b/source/stylesheets/mixins/_variables.scss
@@ -1,4 +1,5 @@
 $global-padding: 30px;
+$global-mobile-padding: 20px;
 $nav-width: 300px;
 $post-height: 60px;
 $header-height: 60px;

--- a/source/stylesheets/views/_layout.css.scss
+++ b/source/stylesheets/views/_layout.css.scss
@@ -56,3 +56,9 @@ footer {
     }
   }
 }
+
+@media screen and (min-width: 320px) and (max-width: 640px) {
+  #container {
+    padding: $header-height $global-mobile-padding 0;
+  }
+}

--- a/source/stylesheets/views/_posts.css.scss
+++ b/source/stylesheets/views/_posts.css.scss
@@ -79,16 +79,34 @@ ul.posts {
 
 @media screen and (min-width: 320px) and (max-width: 640px) {
   ul.posts {
+    padding: $global-mobile-padding 0;
+
     li {
       overflow: auto;
       height: auto;
+      margin-bottom: $global-mobile-padding;
 
       .info {
-        margin-bottom: 12px;
+        margin: 6px 0 6px 75px;
       }
     }
+
     h3.comments {
       display: none;
+    }
+
+    h2 {
+      font-size: 1.2rem;
+
+      a {
+        display: block;
+        line-height: 1.3;
+        margin-bottom: 6px;
+      }
+
+      date {
+        display: block;
+      }
     }
   }
 }


### PR DESCRIPTION
Here's a fix for mobile layout as promised. I've made it more compact, here's how it looks on the iPhone 6:

![](https://photos-3.dropbox.com/t/2/AADGv1g8DKRk13PxSXbQM0kBcLsGSRvX0-CSSjTeu1oAHg/12/7209271/png/1024x768/3/1428444000/0/2/Screenshot%202015-04-07%2021.51.49.png/CLeCuAMgASACIAMoASgC/8XbUuVocTs2PHymNlorSV9_kz03ON0N_anFisdbO4S4)

Single line posts are still the height of the source icon, while longer titles take a bit more space.