### PR TITLE
Fix for bleeding nav panel

### DIFF
--- a/source/stylesheets/views/_layout.css.scss
+++ b/source/stylesheets/views/_layout.css.scss
@@ -30,8 +30,11 @@ nav {
 #container {
   @include _transition(transform);
   background: $background image-url('preloader.gif') no-repeat center center;
-  position: relative;
+  position: fixed;
+  top: 0;
+  bottom: 0;
   z-index: 2;
+  overflow: auto;
   width: 100%;
   padding: $header-height $global-padding 0;
 


### PR DESCRIPTION
Overscrolling on iPhone causes nav panel to appear, this should fix it.

![](https://photos-5.dropbox.com/t/2/AACREGiapV6F2y_MLyutb7Yf3QpxlkkmW6tYjYF28iI1Ig/12/7209271/png/1024x768/3/1428598800/0/2/Screenshot%202015-04-09%2016.09.31.png/CLeCuAMgASACIAMoASgC/L6_HQsSgXXVDwYh43MG9_UopHm7oa-JYq222Y5H_zyE)