### PR TITLE
Show preloader when toggling sources

### DIFF
--- a/source/javascripts/views/_posts.js.coffee
+++ b/source/javascripts/views/_posts.js.coffee
@@ -6,7 +6,10 @@ class Coven.Views.Posts extends Backbone.View
     @collection = new Coven.Collections.Posts
 
   render: ->
+    @$el.empty()
+    $('#container').removeClass 'loaded'
     @collection.fetch
+      reset: true
       data: { sources: @data }
       success: =>
         @renderPosts()

--- a/source/javascripts/views/_sources.js.coffee
+++ b/source/javascripts/views/_sources.js.coffee
@@ -5,9 +5,12 @@ class Coven.Views.Sources extends Backbone.View
   cookieName: '_coven_preferences'
 
   render: ->
-    @posts = new Coven.Views.Posts(el: 'ul.posts', data: @cookie())
-    @posts.render()
     @$el.html @template(cookie: @cookie())
+    @renderPosts()
+
+  renderPosts: ->
+    @posts = @posts || new Coven.Views.Posts(el: 'ul.posts', data: @cookie())
+    @posts.render()
 
   events: ->
     'change input': 'updatePreferences'
@@ -16,7 +19,7 @@ class Coven.Views.Sources extends Backbone.View
     event.preventDefault()
     sources = _.map @$('input:checked'), (input) -> $(input).val()
     @setCookie(sources)
-    @render()
+    @renderPosts()
 
   setCookie: (array) ->
     $.cookie(@cookieName, array)


### PR DESCRIPTION
Hi,

Here's another improvement for the UI — show preloader(spinner) when sources are toggled.

Also keep reusing the same Backbone View and Collection instead of initializing the new ones every time.