### PR TITLE
Prevent long title from pushing comments count

### DIFF
--- a/source/stylesheets/views/_posts.css.scss
+++ b/source/stylesheets/views/_posts.css.scss
@@ -3,6 +3,7 @@ ul.posts {
 
   li {
     @include clearfix;
+    position: relative;
     margin: 0 0 1.5rem 0;
     background: $posts-background;
     height: $post-height;
@@ -25,6 +26,7 @@ ul.posts {
   }
 
   h2 {
+    margin-right: 50px;
     font-size: 1.5rem;
 
     a {
@@ -43,8 +45,8 @@ ul.posts {
   }
 
   h3 {
-    @include float-right;
-    position: relative;
+    position: absolute;
+    right: 10px;
     width: 40px;
 
     a {


### PR DESCRIPTION
Using `position: absolute` to keep comments count in place even if the title is really long:

![](https://photos-5.dropbox.com/t/2/AABbAzLjkp_7uLa-5apAH0SMk-HxPWnWdSu5QtRBIXNRBg/12/7209271/png/32x32/1/1436659200/0/2/Screenshot%202015-07-11%2023.51.29.png/CLeCuAMgASACIAMgBCAFIAYgBygBKAI/E9VsPAwJIzWlCZfn8xaaZL86eHi2-hR47Q3loMJhY3U?size=1280x960&size_mode=2)