### PR TITLE
Enable momentum scrolling on iOS

### DIFF
--- a/source/stylesheets/views/_layout.css.scss
+++ b/source/stylesheets/views/_layout.css.scss
@@ -37,6 +37,7 @@ nav {
   overflow: auto;
   width: 100%;
   padding: $header-height $global-padding 0;
+  -webkit-overflow-scrolling: touch;
 
   &.menu-open {
     @include transform(translate(-$nav-width, 0));


### PR DESCRIPTION
Hey,

Just noticed that there's no inertia scrolling on iOS, so here's a really small fix for that.