### PR TITLE
Prevent posts' comments link from hiding with narrower viewports.

### DIFF
--- a/source/stylesheets/views/_posts.css.scss
+++ b/source/stylesheets/views/_posts.css.scss
@@ -93,10 +93,6 @@ ul.posts {
       }
     }
 
-    h3.comments {
-      display: none;
-    }
-
     h2 {
       font-size: 1.2rem;
 


### PR DESCRIPTION
Very simple bugfix, turns out one of the media queries was erroneously hiding each post's comment link.

Corresponds to Issue #15 